### PR TITLE
disabling the act of sending meta data as part of form data

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ How to use it
 3.  Enjoy life! That's it, you are using a *hidden iframe* instead of
     *XMLHttpRequest*.
 
+4.  This plugin is capable of sending some additional meta data (which are normally
+    sent as headers) inside body and as part of multipart form data. This behaviour
+    is disabled per default because if your server side implementation is not 
+    flexible enough to accept those additional meta data (like Amazon S3 is not),
+    it will be rejected. If you need those set the additional `sendMeta` option
+    to `true` in setup.
 
 Testing
 -------

--- a/js/jquery.bifrost.js
+++ b/js/jquery.bifrost.js
@@ -92,7 +92,11 @@
         }
         data = o;
       }
-      data = $.extend({}, meta, data);
+      if(options.sendMeta == true) {
+        data = $.extend({}, meta, data);
+      } else {
+        data = $.extend({}, data);
+      }
       for (name in data) {
         value = data[name];
         form.append($('<input>').attr({

--- a/src/jquery.bifrost.coffee
+++ b/src/jquery.bifrost.coffee
@@ -77,7 +77,11 @@ class Bifrost
         else if $.isArray(o[name]) then o[name].push value  # For checkboxes
         else o[name] = [ o[name], value ]
       data = o
-    data = $.extend {}, meta, data
+
+    if options.sendMeta is true
+      data = $.extend {}, meta, data
+    else
+      data = $.extend {}, data
 
     # Text inputs
     for name,value of data


### PR DESCRIPTION
this enables usage of this plugin to upload to S3 using signature v4 POST requests. in such requests any additional form data should be mentioned in policy and therefore causes irrelevant complexity.
